### PR TITLE
Prevent us to generate 404s

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,6 +499,11 @@ dummy(123 &#39;&gt;
   <script src="https://storage.googleapis.com/codelab-elements/prettify.js"></script>
   <script src="https://storage.googleapis.com/codelab-elements/codelab-elements.js"></script>
   <script src="//support.google.com/inapp/api.js"></script>
-
+  <script>
+    window.addEventListener('DOMContentLoaded', (event) => {
+      document.getElementById("arrow-back").setAttribute("href", "https://github.com/GoSecure/xxe-workshop/");
+      document.getElementById("done").setAttribute("href", "https://github.com/GoSecure/xxe-workshop/");
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Replaced two links that would lead to 404s. Workaround documented here: https://github.com/googlecodelabs/tools/issues/535. Fixes #3.